### PR TITLE
Some fixes and optimizations

### DIFF
--- a/src/Rutils.cpp
+++ b/src/Rutils.cpp
@@ -38,10 +38,10 @@ RcppExport SEXP tcrossprodcpp_scaled(SEXP X)
         // these need to be RowVectorXd if
         // we do not transpose A first
         Eigen::RowVectorXd mean = A.colwise().mean();
-        Eigen::RowVectorXd std = ((A.rowwise() - mean).colwise().squaredNorm() / (n - 1)).cwiseSqrt();
+        Eigen::RowVectorXd sd = ((A.rowwise() - mean).colwise().squaredNorm() / (n - 1)).cwiseSqrt();
 
         MatrixXd AAt(MatrixXd(n, n).setZero().
-                         selfadjointView<Lower>().rankUpdate(((A.rowwise() - mean).array().rowwise() / std.array()).matrix() ));
+                         selfadjointView<Lower>().rankUpdate(((A.rowwise() - mean).array().rowwise() / sd.array()).matrix() ));
 
         return wrap(AAt);
     } catch (std::exception &ex) {
@@ -68,12 +68,12 @@ RcppExport SEXP crossprodcpp_scaled(SEXP X)
         // these need to be RowVectorXd if
         // we do not transpose A first
         Eigen::RowVectorXd mean = A.colwise().mean();
-        Eigen::RowVectorXd std = ((A.rowwise() - mean).colwise().squaredNorm() / (n - 1)).cwiseSqrt();
+        Eigen::RowVectorXd sd = ((A.rowwise() - mean).colwise().squaredNorm() / (n - 1)).cwiseSqrt();
 
 
         // this currently induces a copy, need to fix if possible
         MatrixXd AtA(MatrixXd(p, p).setZero().
-                         selfadjointView<Lower>().rankUpdate(((A.rowwise() - mean).array().rowwise() / std.array()).array().matrix().adjoint() ));
+                         selfadjointView<Lower>().rankUpdate(((A.rowwise() - mean).array().rowwise() / sd.array()).array().matrix().adjoint() ));
 
         return wrap(AtA);
     } catch (std::exception &ex) {

--- a/src/Rutils.cpp
+++ b/src/Rutils.cpp
@@ -103,12 +103,7 @@ RcppExport SEXP largestEig(SEXP X)
         using Eigen::Lower;
         
         Rcpp::NumericMatrix xx(X);
-        const int n = xx.rows();
-        
-        MatrixXd A(n, n);
-        
-        // Copy data 
-        std::copy(xx.begin(), xx.end(), A.data());
+        const Map<const MatrixXd> A = as< Map<const MatrixXd> >(xx);
         
         Spectra::DenseSymMatProd<double> op(A);
         Spectra::SymEigsSolver< double, Spectra::LARGEST_ALGE, Spectra::DenseSymMatProd<double> > eigs(&op, 1, 4);

--- a/src/Rutils.cpp
+++ b/src/Rutils.cpp
@@ -140,7 +140,7 @@ RcppExport SEXP xpwx(SEXP X, SEXP W)
     const Eigen::Map<MatrixXd> diag(as<Map<MatrixXd> >(W));
     const int n(A.cols());
     MatrixXd AtA(MatrixXd(n, n).setZero().
-    selfadjointView<Lower>().rankUpdate(A.adjoint() * diag.sqrt()));
+    selfadjointView<Lower>().rankUpdate(A.adjoint() * diag.cwiseSqrt()));
     return wrap(AtA);
   } catch (std::exception &ex) {
     forward_exception_to_r(ex);

--- a/src/Rutils.cpp
+++ b/src/Rutils.cpp
@@ -1,14 +1,10 @@
 
 #include "Rutils.h"
 
-using namespace Rcpp;
-using namespace RcppEigen;
-
 //port faster cross product 
 RcppExport SEXP crossprodcpp(SEXP X)
 {
   using namespace Rcpp;
-  using namespace RcppEigen;
   try {
     using Eigen::Map;
     using Eigen::MatrixXd;
@@ -31,7 +27,6 @@ RcppExport SEXP crossprodcpp(SEXP X)
 RcppExport SEXP tcrossprodcpp_scaled(SEXP X)
 {
     using namespace Rcpp;
-    using namespace RcppEigen;
     try {
         using Eigen::Map;
         using Eigen::MatrixXd;
@@ -61,7 +56,6 @@ RcppExport SEXP tcrossprodcpp_scaled(SEXP X)
 RcppExport SEXP crossprodcpp_scaled(SEXP X)
 {
     using namespace Rcpp;
-    using namespace RcppEigen;
     try {
         using Eigen::Map;
         using Eigen::MatrixXd;
@@ -96,7 +90,6 @@ RcppExport SEXP crossprodcpp_scaled(SEXP X)
 RcppExport SEXP largestEig(SEXP X)
 {
     using namespace Rcpp;
-    using namespace RcppEigen;
     try {
         using Eigen::Map;
         using Eigen::MatrixXd;
@@ -126,7 +119,6 @@ RcppExport SEXP largestEig(SEXP X)
 RcppExport SEXP xpwx(SEXP X, SEXP W)
 {
   using namespace Rcpp;
-  using namespace RcppEigen;
   try {
     using Eigen::Map;
     using Eigen::MatrixXd;
@@ -149,7 +141,6 @@ RcppExport SEXP xpwx(SEXP X, SEXP W)
 RcppExport SEXP xxt(SEXP X)
 {
     using namespace Rcpp;
-    using namespace RcppEigen;
     try {
         using Eigen::Map;
         using Eigen::MatrixXd;
@@ -172,7 +163,6 @@ RcppExport SEXP xxt(SEXP X)
 RcppExport SEXP subcpp(SEXP BB, SEXP CC)
 {
   using namespace Rcpp;
-  using namespace RcppEigen;
   try {
     using Eigen::Map;
     using Eigen::MatrixXd;
@@ -193,7 +183,6 @@ RcppExport SEXP subcpp(SEXP BB, SEXP CC)
 RcppExport SEXP addcpp(SEXP BB, SEXP CC)
 {
   using namespace Rcpp;
-  using namespace RcppEigen;
   try {
     using Eigen::Map;
     using Eigen::MatrixXd;
@@ -215,7 +204,6 @@ RcppExport SEXP addcpp(SEXP BB, SEXP CC)
 RcppExport SEXP subSparsecpp(SEXP BB, SEXP CC)
 {
   using namespace Rcpp;
-  using namespace RcppEigen;
   try {
     using Eigen::MappedSparseMatrix;
     using Eigen::SparseMatrix;
@@ -237,7 +225,6 @@ RcppExport SEXP subSparsecpp(SEXP BB, SEXP CC)
 RcppExport SEXP addSparsecpp(SEXP BB, SEXP CC)
 {
   using namespace Rcpp;
-  using namespace RcppEigen;
   try {
     using Eigen::MappedSparseMatrix;
     using Eigen::SparseMatrix;
@@ -259,7 +246,6 @@ RcppExport SEXP addSparsecpp(SEXP BB, SEXP CC)
 RcppExport SEXP LanczosBidiag(SEXP A, SEXP v, SEXP k)
 {
   using namespace Rcpp;
-  using namespace RcppEigen;
   try {
     using Rcpp::List;
     using Eigen::Map;
@@ -325,7 +311,6 @@ RcppExport SEXP LanczosBidiag(SEXP A, SEXP v, SEXP k)
 RcppExport SEXP LanczosBidiagSparse(SEXP A, SEXP v, SEXP k)
 {
   using namespace Rcpp;
-  using namespace RcppEigen;
   try {
     using Rcpp::List;
     using Eigen::Map;
@@ -395,7 +380,6 @@ RcppExport SEXP LanczosBidiagSparse(SEXP A, SEXP v, SEXP k)
 RcppExport SEXP BidiagPoly(SEXP X, SEXP alpha, SEXP beta)
 {
   using namespace Rcpp;
-  using namespace RcppEigen;
   try {
     using Eigen::MatrixXd;
     using Eigen::VectorXd;

--- a/src/Rutils.cpp
+++ b/src/Rutils.cpp
@@ -1,7 +1,7 @@
 
 #include "Rutils.h"
 
-//port faster cross product 
+//port faster cross product
 RcppExport SEXP crossprodcpp(SEXP X)
 {
   using namespace Rcpp;
@@ -23,7 +23,7 @@ RcppExport SEXP crossprodcpp(SEXP X)
 }
 
 
-//port faster scaledcross product 
+//port faster scaledcross product
 RcppExport SEXP tcrossprodcpp_scaled(SEXP X)
 {
     using namespace Rcpp;
@@ -33,16 +33,16 @@ RcppExport SEXP tcrossprodcpp_scaled(SEXP X)
         using Eigen::Lower;
         const Eigen::Map<MatrixXd> A(as<Map<MatrixXd> >(X));
         const int n(A.rows());
-        
-        
-        // these need to be RowVectorXd if 
+
+
+        // these need to be RowVectorXd if
         // we do not transpose A first
         Eigen::RowVectorXd mean = A.colwise().mean();
         Eigen::RowVectorXd std = ((A.rowwise() - mean).colwise().squaredNorm() / (n - 1)).cwiseSqrt();
-        
+
         MatrixXd AAt(MatrixXd(n, n).setZero().
                          selfadjointView<Lower>().rankUpdate(((A.rowwise() - mean).array().rowwise() / std.array()).matrix() ));
-        
+
         return wrap(AAt);
     } catch (std::exception &ex) {
         forward_exception_to_r(ex);
@@ -52,7 +52,7 @@ RcppExport SEXP tcrossprodcpp_scaled(SEXP X)
     return R_NilValue; //-Wall
 }
 
-//port faster scaled cross product 
+//port faster scaled cross product
 RcppExport SEXP crossprodcpp_scaled(SEXP X)
 {
     using namespace Rcpp;
@@ -63,18 +63,18 @@ RcppExport SEXP crossprodcpp_scaled(SEXP X)
         const Eigen::Map<MatrixXd> A(as<Map<MatrixXd> >(X));
         const int n(A.rows());
         const int p(A.cols());
-        
-        
-        // these need to be RowVectorXd if 
+
+
+        // these need to be RowVectorXd if
         // we do not transpose A first
         Eigen::RowVectorXd mean = A.colwise().mean();
         Eigen::RowVectorXd std = ((A.rowwise() - mean).colwise().squaredNorm() / (n - 1)).cwiseSqrt();
-        
-        
+
+
         // this currently induces a copy, need to fix if possible
         MatrixXd AtA(MatrixXd(p, p).setZero().
                          selfadjointView<Lower>().rankUpdate(((A.rowwise() - mean).array().rowwise() / std.array()).array().matrix().adjoint() ));
-        
+
         return wrap(AtA);
     } catch (std::exception &ex) {
         forward_exception_to_r(ex);
@@ -86,7 +86,7 @@ RcppExport SEXP crossprodcpp_scaled(SEXP X)
 
 
 
-//port faster cross product 
+//port faster cross product
 RcppExport SEXP largestEig(SEXP X)
 {
     using namespace Rcpp;
@@ -94,18 +94,17 @@ RcppExport SEXP largestEig(SEXP X)
         using Eigen::Map;
         using Eigen::MatrixXd;
         using Eigen::Lower;
-        
-        Rcpp::NumericMatrix xx(X);
-        const Map<const MatrixXd> A = as< Map<const MatrixXd> >(xx);
-        
+
+        const Map<MatrixXd> A(as< Map<MatrixXd> >(X));
+
         Spectra::DenseSymMatProd<double> op(A);
         Spectra::SymEigsSolver< double, Spectra::LARGEST_ALGE, Spectra::DenseSymMatProd<double> > eigs(&op, 1, 4);
-        
+
         eigs.init();
         eigs.compute(1000, 0.0001);
         Eigen::VectorXd eigenvals = eigs.eigenvalues();
         double d = eigenvals[0];
-        
+
         return wrap(d);
     } catch (std::exception &ex) {
         forward_exception_to_r(ex);
@@ -115,7 +114,7 @@ RcppExport SEXP largestEig(SEXP X)
     return R_NilValue; //-Wall
 }
 
-//port faster cross product 
+//port faster cross product
 RcppExport SEXP xpwx(SEXP X, SEXP W)
 {
   using namespace Rcpp;
@@ -137,7 +136,7 @@ RcppExport SEXP xpwx(SEXP X, SEXP W)
   return R_NilValue; //-Wall
 }
 
-//port faster cross product 
+//port faster cross product
 RcppExport SEXP xxt(SEXP X)
 {
     using namespace Rcpp;
@@ -146,7 +145,7 @@ RcppExport SEXP xxt(SEXP X)
         using Eigen::MatrixXd;
         using Eigen::Lower;
         const Eigen::Map<MatrixXd> A(as<Map<MatrixXd> >(X));
-        
+
         const int n(A.rows());
         MatrixXd AtA(MatrixXd(n, n).setZero().
                          selfadjointView<Lower>().rankUpdate(A));
@@ -258,7 +257,7 @@ RcppExport SEXP LanczosBidiag(SEXP A, SEXP v, SEXP k)
     const MapVecd Vinit(as<MapVecd>(v));
     const int kk(as<int>(k));
     //const bool reorth(as<bool>(reorthog));
-    
+
     VectorXd v(Vinit);
     VectorXd u(AA.rows());
     VectorXd Uprev(v.size());
@@ -266,12 +265,12 @@ RcppExport SEXP LanczosBidiag(SEXP A, SEXP v, SEXP k)
     MatrixXd B(MatrixXd::Zero(kk, kk));
     double d(0);
     //VectorXd Unew(v.size());
-    
+
     v.normalize();
-    
+
     VectorXd beta(kk);
     VectorXd alpha(kk);
-    
+
     for (int i = 0; i < kk; i++) {
       Uprev = u;
       u = AA * v;
@@ -285,15 +284,15 @@ RcppExport SEXP LanczosBidiag(SEXP A, SEXP v, SEXP k)
       beta(i) = Vnew.norm();
       v = Vnew.array() / beta(i);
     }
-    
+
     B.diagonal() = alpha;
     for (int i = 0; i < kk - 1; i++) {
       B(i, i + 1) = beta(i);
     }
-    
+
     JacobiSVD<MatrixXd> svd(B);
     d = svd.singularValues()(0);
-    
+
     return List::create(Named("d") = d,
                         Named("u") = u,
                         Named("v") = v,
@@ -319,7 +318,7 @@ RcppExport SEXP LanczosBidiagSparse(SEXP A, SEXP v, SEXP k)
     using Eigen::SparseMatrix;
     typedef Eigen::MappedSparseMatrix<double> MSpMat;
     typedef Eigen::SparseMatrix<double> SpMat;
-    
+
     using Eigen::VectorXd;
     using Eigen::JacobiSVD;
     typedef Eigen::Map<VectorXd> MapVecd;
@@ -327,7 +326,7 @@ RcppExport SEXP LanczosBidiagSparse(SEXP A, SEXP v, SEXP k)
     const MapVecd Vinit(as<MapVecd>(v));
     const int kk(as<int>(k));
     //const bool reorth(as<bool>(reorthog));
-    
+
     VectorXd v(Vinit);
     VectorXd u(AA.rows());
     VectorXd Uprev(v.size());
@@ -335,12 +334,12 @@ RcppExport SEXP LanczosBidiagSparse(SEXP A, SEXP v, SEXP k)
     MatrixXd B(MatrixXd::Zero(kk, kk));
     double d(0);
     //VectorXd Unew(v.size());
-    
+
     v.normalize();
-        
+
     VectorXd beta(kk);
     VectorXd alpha(kk);
-    
+
     for (int i = 0; i < kk; i++) {
       Uprev = u;
       u = AA * v;
@@ -354,15 +353,15 @@ RcppExport SEXP LanczosBidiagSparse(SEXP A, SEXP v, SEXP k)
       beta(i) = Vnew.norm();
       v = Vnew.array() / beta(i);
     }
-    
+
     B.diagonal() = alpha;
     for (int i = 0; i < kk - 1; i++) {
       B(i, i + 1) = beta(i);
     }
-    
+
     JacobiSVD<MatrixXd> svd(B);
     d = svd.singularValues()(0);
-    
+
     return List::create(Named("d") = d,
                         Named("u") = u,
                         Named("v") = v,
@@ -376,7 +375,7 @@ RcppExport SEXP LanczosBidiagSparse(SEXP A, SEXP v, SEXP k)
   return R_NilValue; //-Wall
 }
 
-//port faster cross product 
+//port faster cross product
 RcppExport SEXP BidiagPoly(SEXP X, SEXP alpha, SEXP beta)
 {
   using namespace Rcpp;
@@ -387,19 +386,19 @@ RcppExport SEXP BidiagPoly(SEXP X, SEXP alpha, SEXP beta)
     const MapVecd alph(as<MapVecd>(alpha));
     const MapVecd bet(as<MapVecd>(beta));
     const double xx(as<double>(X));
-    
+
     double p0(1 / alph(0));
     double q0(1);
     double p(p0);
     double q(q0);
-    
+
     for (int k = 0; k < alph.size() - 1; k++) {
       q = (xx * p0 - alph(k) * q0) / bet(k);
       p  = (q - bet(k) * p0) / alph(k + 1);
       p0 = p;
       q0 = q;
     }
-    
+
     return wrap(p);
   } catch (std::exception &ex) {
     forward_exception_to_r(ex);
@@ -408,4 +407,3 @@ RcppExport SEXP BidiagPoly(SEXP X, SEXP alpha, SEXP beta)
   }
   return R_NilValue; //-Wall
 }
-

--- a/src/Rutils.cpp
+++ b/src/Rutils.cpp
@@ -38,7 +38,7 @@ RcppExport SEXP tcrossprodcpp_scaled(SEXP X)
         // these need to be RowVectorXd if 
         // we do not transpose A first
         Eigen::RowVectorXd mean = A.colwise().mean();
-        Eigen::RowVectorXd std = ((A.rowwise() - mean).array().square().colwise().sum() / (n - 1)).sqrt();
+        Eigen::RowVectorXd std = ((A.rowwise() - mean).colwise().squaredNorm() / (n - 1)).cwiseSqrt();
         
         MatrixXd AAt(MatrixXd(n, n).setZero().
                          selfadjointView<Lower>().rankUpdate(((A.rowwise() - mean).array().rowwise() / std.array()).matrix() ));
@@ -68,7 +68,7 @@ RcppExport SEXP crossprodcpp_scaled(SEXP X)
         // these need to be RowVectorXd if 
         // we do not transpose A first
         Eigen::RowVectorXd mean = A.colwise().mean();
-        Eigen::RowVectorXd std = ((A.rowwise() - mean).array().square().colwise().sum() / (n - 1)).sqrt();
+        Eigen::RowVectorXd std = ((A.rowwise() - mean).colwise().squaredNorm() / (n - 1)).cwiseSqrt();
         
         
         // this currently induces a copy, need to fix if possible


### PR DESCRIPTION
1. Line 143, `diag.sqrt()` is changed to `diag.cwiseSqrt()`. The latter is defined for the Matrix type, and avoids compilation error in the new 3.3 version of Eigen
2. Avoids memory copy in `largestEig()`
3. Uses `squaredNorm()` to calculate standard deviations
4. Other tweaks